### PR TITLE
Make @cypress/webpack-preprocessor a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Cypress preprocessor for bundling JavaScript via webpack, with dependencies incl
 
 ## Why?
 
-This preprocessor is a wrapper for the [webpack preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor). The webpack preprocessor does not include any extra dependencies (e.g. `babel-loader`, `ts-loader`), since most users will use their own `webpack.config.js` with it and already have the necessary dependencies installed. This preprocessor is for users who do not have those dependencies installed and would prefer not to configure the preprocessor to handle things like TypeScript and CoffeeScript.
+This preprocessor is a wrapper for [@cypress/webpack-preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor). The webpack preprocessor does not include any extra dependencies (e.g. `babel-loader`, `ts-loader`), since most users will use their own `webpack.config.js` with it and already have the necessary dependencies installed. This preprocessor is for users who do not have those dependencies installed and would prefer not to configure the preprocessor to handle things like TypeScript and CoffeeScript.
 
 ## Installation
 
+Note that installing [@cypress/webpack-preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor) is also required. This allows you to update its version separately from this wrapper.
+
 ```sh
-npm install --save-dev @cypress/webpack-batteries-included-preprocessor
+npm install --save-dev @cypress/webpack-batteries-included-preprocessor @cypress/webpack-preprocessor
 ```
 
 ## Usage
@@ -21,14 +23,14 @@ npm install --save-dev @cypress/webpack-batteries-included-preprocessor
 In your project's [plugins file](https://on.cypress.io/guides/tooling/plugins-guide.html):
 
 ```javascript
-const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const webpackPreprocessor = require('@cypress/webpack-batteries-included-preprocessor')
 
 module.exports = (on) => {
   on('file:preprocessor', webpackPreprocessor())
 }
 ```
 
-This preprocessor supports the same options as the [webpack preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor), so see its README for more information.
+This preprocessor supports the same options as [@cypress/webpack-preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor), so see its README for more information.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     }
   },
   "dependencies": {
-<<<<<<< Updated upstream
     "@babel/core": "7.10.5",
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "7.10.4",
@@ -23,7 +22,6 @@
     "@babel/preset-env": "7.10.4",
     "@babel/preset-react": "7.10.4",
     "@babel/runtime": "7.10.5",
-    "@cypress/webpack-preprocessor": "5.4.2",
     "babel-loader": "8.1.0",
     "babel-plugin-add-module-exports": "1.0.2",
     "coffee-loader": "0.9.0",
@@ -35,6 +33,7 @@
   },
   "devDependencies": {
     "@cypress/eslint-plugin-dev": "5.0.0",
+    "@cypress/webpack-preprocessor": "5.4.2",
     "@fellow/eslint-plugin-coffee": "0.4.13",
     "@types/mocha": "8.0.0",
     "@types/webpack": "4.41.21",
@@ -53,45 +52,6 @@
     "react": "16.13.1",
     "semantic-release": "17.1.1",
     "typescript": "3.9.7"
-=======
-    "@babel/core": "^7.10.5",
-    "@babel/plugin-proposal-class-properties": "^7.10.4",
-    "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
-    "@babel/plugin-transform-runtime": "^7.10.5",
-    "@babel/preset-env": "^7.10.4",
-    "@babel/preset-react": "^7.10.4",
-    "@babel/runtime": "^7.10.5",
-    "babel-loader": "^8.1.0",
-    "babel-plugin-add-module-exports": "^1.0.2",
-    "coffee-loader": "^0.9.0",
-    "coffeescript": "^1.12.7",
-    "ts-loader": "^8.0.1",
-    "tsconfig": "^7.0.0",
-    "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "webpack": "^4.43.0"
-  },
-  "devDependencies": {
-    "@cypress/eslint-plugin-dev": "^5.0.0",
-    "@cypress/webpack-preprocessor": "^5.4.2",
-    "@fellow/eslint-plugin-coffee": "^0.4.13",
-    "@types/mocha": "^8.0.0",
-    "@types/webpack": "^4.41.21",
-    "@typescript-eslint/eslint-plugin": "^3.7.0",
-    "@typescript-eslint/parser": "^3.7.0",
-    "babel-eslint": "^10.1.0",
-    "chai": "^4.2.0",
-    "eslint": "^7.5.0",
-    "eslint-plugin-cypress": "^2.11.1",
-    "eslint-plugin-json-format": "^2.0.1",
-    "eslint-plugin-mocha": "^7.0.1",
-    "eslint-plugin-react": "^7.20.3",
-    "fs-extra": "^9.0.1",
-    "lint-staged": "^10.2.11",
-    "mocha": "^8.0.1",
-    "react": "^16.13.1",
-    "semantic-release": "^17.1.1",
-    "typescript": "^3.9.7"
->>>>>>> Stashed changes
   },
   "peerDependencies": {
     "@cypress/webpack-preprocessor": "^5.4.2"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     }
   },
   "dependencies": {
+<<<<<<< Updated upstream
     "@babel/core": "7.10.5",
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "7.10.4",
@@ -52,6 +53,48 @@
     "react": "16.13.1",
     "semantic-release": "17.1.1",
     "typescript": "3.9.7"
+=======
+    "@babel/core": "^7.10.5",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
+    "@babel/plugin-transform-runtime": "^7.10.5",
+    "@babel/preset-env": "^7.10.4",
+    "@babel/preset-react": "^7.10.4",
+    "@babel/runtime": "^7.10.5",
+    "babel-loader": "^8.1.0",
+    "babel-plugin-add-module-exports": "^1.0.2",
+    "coffee-loader": "^0.9.0",
+    "coffeescript": "^1.12.7",
+    "ts-loader": "^8.0.1",
+    "tsconfig": "^7.0.0",
+    "tsconfig-paths-webpack-plugin": "^3.2.0",
+    "webpack": "^4.43.0"
+  },
+  "devDependencies": {
+    "@cypress/eslint-plugin-dev": "^5.0.0",
+    "@cypress/webpack-preprocessor": "^5.4.2",
+    "@fellow/eslint-plugin-coffee": "^0.4.13",
+    "@types/mocha": "^8.0.0",
+    "@types/webpack": "^4.41.21",
+    "@typescript-eslint/eslint-plugin": "^3.7.0",
+    "@typescript-eslint/parser": "^3.7.0",
+    "babel-eslint": "^10.1.0",
+    "chai": "^4.2.0",
+    "eslint": "^7.5.0",
+    "eslint-plugin-cypress": "^2.11.1",
+    "eslint-plugin-json-format": "^2.0.1",
+    "eslint-plugin-mocha": "^7.0.1",
+    "eslint-plugin-react": "^7.20.3",
+    "fs-extra": "^9.0.1",
+    "lint-staged": "^10.2.11",
+    "mocha": "^8.0.1",
+    "react": "^16.13.1",
+    "semantic-release": "^17.1.1",
+    "typescript": "^3.9.7"
+>>>>>>> Stashed changes
+  },
+  "peerDependencies": {
+    "@cypress/webpack-preprocessor": "^5.4.2"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
BREAKING CHANGE: It's now required to install @cypress/webpack-preprocessor alongside this wrapper